### PR TITLE
adding ability to select by LIKE clause on string fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ script:
   - make test-example
   - go run marlowc/main.go -input examples/library/models -stdout=true
   - make example
+  - ./examples/lib
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f ./coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ test: $(GO_SRC) $(VENDOR_DIR) $(INTERCHANGE_OBJ) lint
 test-example: $(EXAMPLE_SRC)
 	$(GO) run $(MAIN) -input=$(EXAMPLE_MODEL_DIR)
 	$(GO) test $(EXAMPLE_TEST_FLAGS) -p=$(MAX_TEST_CONCURRENCY) $(EXAMPLE_MODEL_DIR)
+	$(VET) $(VET_FLAGS) $(EXAMPLE_MODEL_DIR)
 
 $(VENDOR_DIR):
 	$(GO) get -v -u github.com/modocache/gover

--- a/examples/library/main.go
+++ b/examples/library/main.go
@@ -107,8 +107,12 @@ func main() {
 
 	log.Printf("author query w/o values: %v", &models.AuthorBlueprint{})
 
-	log.Printf("author query w values: %v", &models.AuthorBlueprint{
+	log.Printf("author query w ID exact matches: %v", &models.AuthorBlueprint{
 		ID: []int{123, 456},
+	})
+
+	log.Printf("author query w NameLike: %v", &models.AuthorBlueprint{
+		NameLike: []string{"danny"},
 	})
 
 	authorStore := models.AuthorStore{DB: db}

--- a/marlow/features/blueprint.go
+++ b/marlow/features/blueprint.go
@@ -58,7 +58,7 @@ func writeBlueprint(destination io.Writer, bp blueprint, imports chan<- string) 
 		"CLAUSE_ITEM":  "_clauseItem",
 	}
 
-	clauseMethods := make([]string, 0)
+	var clauseMethods []string
 
 	for name, config := range bp.fields {
 		methods, e := writeFieldClauseMethods(out, bp, name, config)

--- a/marlow/features/queryable.go
+++ b/marlow/features/queryable.go
@@ -74,7 +74,7 @@ func writeQueryableLookup(o io.Writer, record url.Values, fields map[string]url.
 
 		// Prepare the sql statement that will be sent to the DB.
 		out.Println(
-			"%s := bytes.NewBufferString(fmt.Sprintf(\"SELECT %s FROM %s\"))",
+			"%s := bytes.NewBufferString(\"SELECT %s FROM %s\")",
 			symbols["FULL_QUERY_BUFFER"],
 			strings.Join(fieldList, ","),
 			table,

--- a/marlow/reader_test.go
+++ b/marlow/reader_test.go
@@ -82,10 +82,7 @@ func Test_Reader(t *testing.T) {
 			}
 			`)
 			e := Compile(output, source)
-			g.Assert(e).Equal(nil)
-			ts := token.NewFileSet()
-			_, e = parser.ParseFile(ts, "", output, parser.AllErrors)
-			g.Assert(e).Equal(nil)
+			g.Assert(e.Error()).Equal("invalid-table")
 		})
 
 	})


### PR DESCRIPTION
closes #25 

introduces:

```go
records, e := store.FindAuthors(&AuthorBlueprint{
  NameLike: []string{/* ... */},
})
```