### PR TITLE
adding more coverage for generated code

### DIFF
--- a/examples/library/models/author_test.go
+++ b/examples/library/models/author_test.go
@@ -141,6 +141,13 @@ func Test_Author(t *testing.T) {
 			g.Assert(len(authors)).Equal(20)
 		})
 
+		g.It("allows the consumer to search for authors w/ blueprint (explicit offset)", func() {
+			authors, e := store.FindAuthors(&AuthorBlueprint{Offset: 1, Limit: 1})
+			g.Assert(e).Equal(nil)
+			g.Assert(len(authors)).Equal(1)
+			g.Assert(authors[0].ID).Equal(2)
+		})
+
 		g.It("allows the consumer to search for authors by explicit Name", func() {
 			authors, e := store.FindAuthors(&AuthorBlueprint{
 				Name: []string{"author-11", "author-21", "not-exists"},
@@ -177,6 +184,12 @@ func Test_Author(t *testing.T) {
 
 			g.Assert(authors[1].Name).Equal("other author")
 			g.Assert(authors[1].UniversityID.Valid).Equal(false)
+		})
+
+		g.It("allows consumer to count w/ nil blueprint", func() {
+			count, e := store.CountAuthors(nil)
+			g.Assert(e).Equal(nil)
+			g.Assert(count).Equal(generatedAuthorCount + 1)
 		})
 
 		g.It("allows consumer to search by authors with null UniversityID", func() {

--- a/examples/library/models/book_test.go
+++ b/examples/library/models/book_test.go
@@ -186,12 +186,22 @@ func Test_Book(t *testing.T) {
 			g.Assert(len(books)).Equal(1)
 		})
 
-		g.It("allows the consumer to count books by blueprint", func() {
-			count, e := store.CountBooks(&BookBlueprint{
-				ID: []int{1, 2},
+		g.Describe("store.CountBooks", func() {
+
+			g.It("allows the consumer to count books with nil blueprint", func() {
+				count, e := store.CountBooks(nil)
+				g.Assert(e).Equal(nil)
+				g.Assert(count).Equal(testBookCount)
 			})
-			g.Assert(e).Equal(nil)
-			g.Assert(count).Equal(2)
+
+			g.It("allows the consumer to count books by blueprint", func() {
+				count, e := store.CountBooks(&BookBlueprint{
+					ID: []int{1, 2},
+				})
+				g.Assert(e).Equal(nil)
+				g.Assert(count).Equal(2)
+			})
+
 		})
 
 		g.It("allows the consumer to select explicit book ids", func() {


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`85feb80`] | adding coverage for generated code |

| :tophat: | @dadleyy |
| :--- | :--- |
| :paperclip: | |


[`85feb80`]: https://github.com/dadleyy/marlow/commit/85feb80a13f3fac7f95c8536d6a0e5790b3984e4