### PR TITLE
updating gendry README img url and explaining pr template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,6 +9,18 @@ If you are interested in contributing, please familiarize yourself with the auto
 for continuous integration _before_ opening a pull request; while not absolutely necessary, it will save you some
 surprises when you do open a pull request that could've been mitigated locally.
 
+### Pull requests
+
+When opening a pull request, be sure to use the `PULL_REQUEST_TEMPLATE.md` file in the `.github` directory (github should automatically fill your PR description with the contents of that file) as a template for your PR's description. The first table (underneath "Notable Changes") should explicitly call out any important line changes, as well as the github issue number and/or general reason for the change.
+
+The second table should be used to identify other developers that should review the code. This includes both the primary reviewer - using a `@mention` next to the :tophat: row - and any other developers that may be interested in the diff next to the :paperclip:. For example:
+
+> | :tophat: | @dadleyy |
+> | :--- | :--- |
+> | :paperclip: | @sizethree/golang |
+
+would indicate that @dadleyy is primarily responsible for reviewing the code, while the @sizethree/golang team would be interested in it.
+
 
 [Marlow]: https://github.com/dadleyy/marlow
 [travis]: https://travis-ci.org/dadleyy/marlow

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 | :--- | :--- |
 | | |
 
-| :tophat: | @dadleyy |
+| [:tophat:][contributing] | @dadleyy |
 | :--- | :--- |
-| :paperclip: | |
+| [:paperclip:][contributing] | |
+
+[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -162,6 +162,6 @@ generated coverage badge provided by [gendry]
 [commits.url]: https://github.com/dadleyy/marlow
 [awesome.img]: https://img.shields.io/badge/%F0%9F%95%B6-awesome--go-443f5e.svg?colorA=c3a1bb&style=flat-square
 [awesome.url]: https://awesome-go.com/#orm
-[generated-coverage.img]: http://coverage.marlow.sizethree.cc
+[generated-coverage.img]: http://gendry.sizethree.cc/coverage/dadleyy/marlow.svg
 [generated-coverage.url]: http://coverage.marlow.sizethree.cc.s3.amazonaws.com/latest/library.coverage.html
 [gendry]: https://bitbucket.org/dadleyy/gendry


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`904c15e`] | changing gendry url for generated code badge |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |

[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`904c15e`]: https://github.com/dadleyy/marlow/commit/904c15ef86bd062259878c99b5f5d8b90ce2aa7c