### PR TITLE
creation api :rocketship: - closes GH-53

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,14 @@ VET_FLAGS=
 
 MAX_TEST_CONCURRENCY=1
 
-TEST_FLAGS=-covermode=atomic -v -coverprofile={{.Dir}}/.coverprofile
+TEST_VERBOSITY=-v
+TEST_FLAGS=-covermode=atomic $(TEST_VERBOSITY) -coverprofile={{.Dir}}/.coverprofile
 TEST_LIST_FMT='{{if len .TestGoFiles}}"go test {{.ImportPath}} $(TEST_FLAGS)"{{end}}'
 
 LIBRARY_COVERAGE_OUTPUT_DIR=./dist/coverage
 LIBRARY_EXAMPLE_COVERAGE_REPORT=$(LIBRARY_COVERAGE_OUTPUT_DIR)/library.coverage.txt
 LIBRARY_EXAMPLE_COVERAGE_DISTRIBUTABLE=$(LIBRARY_COVERAGE_OUTPUT_DIR)/library.coverage.html
-LIBRARY_EXAMPLE_TEST_FLAGS=-covermode=atomic -coverprofile=$(LIBRARY_EXAMPLE_COVERAGE_REPORT)
+LIBRARY_EXAMPLE_TEST_FLAGS=-covermode=atomic $(TEST_VERBOSITY) -coverprofile=$(LIBRARY_EXAMPLE_COVERAGE_REPORT)
 
 all: $(EXE)
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ generated coverage badge provided by [gendry]
 [golang]: https://golang.org
 [report.img]: https://goreportcard.com/badge/github.com/dadleyy/marlow?style=flat-square
 [report.url]: https://goreportcard.com/report/github.com/dadleyy/marlow
-[travis.img]: https://img.shields.io/travis/dadleyy/marlow.svg?style=flat-square
+[travis.img]: https://img.shields.io/travis/dadleyy/marlow/master.svg?style=flat-square
 [travis.url]: https://travis-ci.org/dadleyy/marlow
 [godoc.img]: http://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square
 [godoc.url]: https://godoc.org/github.com/dadleyy/marlow/marlow

--- a/examples/library/main.go
+++ b/examples/library/main.go
@@ -29,7 +29,7 @@ func withTx(db *sql.DB, block func(*sql.Tx) error) error {
 }
 
 func addBooks(tx *sql.Tx) error {
-	stmt, e := tx.Prepare("insert into books(id, title, author_id, page_count) values(?, ?, ?, ?)")
+	stmt, e := tx.Prepare("insert into books(id, title, author, page_count) values(?, ?, ?, ?)")
 
 	if e != nil {
 		log.Fatal(e)

--- a/examples/library/models/author.go
+++ b/examples/library/models/author.go
@@ -9,7 +9,7 @@ import "database/sql"
 // Author represents an author of a book.
 type Author struct {
 	table        bool          `marlow:"tableName=authors"`
-	ID           int           `marlow:"column=id"`
+	ID           int           `marlow:"column=id&autoIncrement=true"`
 	Name         string        `marlow:"column=name"`
 	UniversityID sql.NullInt64 `marlow:"column=university_id"`
 }

--- a/examples/library/models/author_test.go
+++ b/examples/library/models/author_test.go
@@ -309,6 +309,24 @@ func Test_Author(t *testing.T) {
 			g.Assert(count).Equal(2)
 		})
 
+		g.Describe("CreateAuthors", func() {
+			g.It("returns immediately with 0 if no authors", func() {
+				s, e := store.CreateAuthors()
+				g.Assert(e).Equal(nil)
+				g.Assert(s).Equal(0)
+			})
+
+			g.It("returns the number of authors created", func() {
+				s, e := store.CreateAuthors(Author{Name: "Danny"}, Author{Name: "Amelia"})
+				g.Assert(e).Equal(nil)
+				g.Assert(s).Equal(2)
+				found, e := store.FindAuthors(&AuthorBlueprint{Name: []string{"Amelia"}})
+				g.Assert(e).Equal(nil)
+				g.Assert(len(found)).Equal(1)
+				g.Assert(found[0].ID > 0).Equal(true)
+			})
+		})
+
 		g.Describe("DeleteAuthors", func() {
 
 			g.It("returns an error and a negative number with an empty blueprint", func() {

--- a/examples/library/models/book.go
+++ b/examples/library/models/book.go
@@ -9,10 +9,10 @@ import "database/sql"
 // Book represents a book in the example application
 type Book struct {
 	table     string        `marlow:"defaultLimit=10"`
-	ID        int           `marlow:"column=id"`
+	ID        int           `marlow:"column=id&autoIncrement=true"`
 	Title     string        `marlow:"column=title"`
-	AuthorID  int           `marlow:"column=author_id&references=Author"`
-	SeriesID  sql.NullInt64 `marlow:"column=series_id&references=Author"`
+	AuthorID  int           `marlow:"column=author&references=Author"`
+	SeriesID  sql.NullInt64 `marlow:"column=series"`
 	PageCount int           `marlow:"column=page_count"`
 }
 

--- a/examples/library/schema.sql
+++ b/examples/library/schema.sql
@@ -1,17 +1,17 @@
 drop table if exists authors;
 
 create table authors (
-  id integer not null primary key,
-  name text,
-  university_id integer
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  university_id INTEGER
 );
 
 drop table if exists books;
 
 create table books (
-  id integer not null primary key,
-  title text,
-  author_id integer not null,
-  series_id integer,
-  page_count integer not null
+  id INTEGER PRIMARY KEY,
+  title TEXT,
+  author INTEGER NOT NULL,
+  series INTEGER,
+  page_count INTEGER NOT NULL
 );

--- a/marlow/constants/config.go
+++ b/marlow/constants/config.go
@@ -27,6 +27,9 @@ const (
 	// StoreCountMethodPrefixConfigOption determines the prefix used when adding the main count method to the store.
 	StoreCountMethodPrefixConfigOption = "storeCountMethodPrefix"
 
+	// ColumnAutoIncrementFlag used to determine if primary key should be inserted during creation.
+	ColumnAutoIncrementFlag = "autoIncrement"
+
 	// UpdateFieldMethodPrefixConfigOption is the method prefix of update methods for individual fields.
 	UpdateFieldMethodPrefixConfigOption = "updateMethodPrefix"
 

--- a/marlow/features/createable.go
+++ b/marlow/features/createable.go
@@ -1,0 +1,181 @@
+package features
+
+import "io"
+import "fmt"
+import "sort"
+import "net/url"
+import "strings"
+import "github.com/gedex/inflector"
+import "github.com/dadleyy/marlow/marlow/writing"
+import "github.com/dadleyy/marlow/marlow/constants"
+
+type createableSymbolList struct {
+	RecordParam              string
+	QueryBuffer              string
+	RowValueString           string
+	StatementPlaceholderList string
+	StatementValueList       string
+	Statement                string
+	StatementError           string
+	SingleRecord             string
+	ExecResult               string
+	ExecError                string
+	AffectedResult           string
+	AffectedError            string
+}
+
+// NewCreateableGenerator returns a reader that will generate a record store's creation api.
+func NewCreateableGenerator(record url.Values, fields map[string]url.Values, imports chan<- string) io.Reader {
+	pr, pw := io.Pipe()
+
+	storeName := record.Get(constants.StoreNameConfigOption)
+	recordName := record.Get(constants.RecordNameConfigOption)
+	methodName := fmt.Sprintf("Create%s", inflector.Pluralize(recordName))
+	tableName := record.Get(constants.TableNameConfigOption)
+
+	symbols := createableSymbolList{
+		RecordParam:              "_records",
+		QueryBuffer:              "_query",
+		RowValueString:           "_placeholders",
+		StatementPlaceholderList: "_placeholderList",
+		StatementValueList:       "_valueList",
+		Statement:                "_statement",
+		StatementError:           "_e",
+		SingleRecord:             "_record",
+		ExecResult:               "_result",
+		ExecError:                "_execError",
+		AffectedResult:           "_affectedResult",
+		AffectedError:            "_affectedError",
+	}
+
+	params := []writing.FuncParam{
+		{Symbol: symbols.RecordParam, Type: fmt.Sprintf("...%s", recordName)},
+	}
+
+	returns := []string{
+		"int64",
+		"error",
+	}
+
+	go func() {
+		gosrc := writing.NewGoWriter(pw)
+
+		gosrc.Comment("[marlow] createable")
+
+		// gosrc.Println("/* %s %s %s %s", storeName, recordName, methodName, tableName)
+
+		e := gosrc.WithMethod(methodName, storeName, params, returns, func(scope url.Values) error {
+			gosrc.WithIf("len(%s) == 0", func(url.Values) error {
+				gosrc.Println("return 0, nil")
+				return nil
+			}, symbols.RecordParam)
+
+			columnList := make([]string, 0, len(fields))
+			placeholders := make([]string, 0, len(fields))
+			fieldLookup := make(map[string]string, len(fields))
+
+			for field, c := range fields {
+				columnName := c.Get(constants.ColumnConfigOption)
+
+				if c.Get(constants.ColumnAutoIncrementFlag) != "" {
+					continue
+				}
+
+				columnList = append(columnList, columnName)
+				placeholders = append(placeholders, "?")
+				fieldLookup[columnName] = field
+			}
+
+			sort.Strings(columnList)
+
+			gosrc.Println("%s := make([]string, 0, len(%s))", symbols.StatementPlaceholderList, symbols.RecordParam)
+			gosrc.Println("%s := make([]interface{}, 0, len(%s))", symbols.StatementValueList, symbols.RecordParam)
+
+			gosrc.WithIter("_, %s := range %s", func(url.Values) error {
+				gosrc.Println("%s := \"(%s)\"", symbols.RowValueString, strings.Join(placeholders, ", "))
+				fieldReferences := make([]string, 0, len(columnList))
+
+				for _, columnName := range columnList {
+					field := fieldLookup[columnName]
+					fieldReferences = append(fieldReferences, fmt.Sprintf("%s.%s", symbols.SingleRecord, field))
+				}
+
+				gosrc.Println(
+					"%s = append(%s, %s)",
+					symbols.StatementValueList,
+					symbols.StatementValueList,
+					strings.Join(fieldReferences, ","),
+				)
+
+				gosrc.Println(
+					"%s = append(%s, %s)",
+					symbols.StatementPlaceholderList,
+					symbols.StatementPlaceholderList,
+					symbols.RowValueString,
+				)
+				return nil
+			}, symbols.SingleRecord, symbols.RecordParam)
+
+			gosrc.Println("%s := new(bytes.Buffer)", symbols.QueryBuffer)
+
+			gosrc.Println(
+				"fmt.Fprintf(%s, \"INSERT INTO %s ( %s ) VALUES %%s;\", strings.Join(%s, \", \"))\n",
+				symbols.QueryBuffer,
+				tableName,
+				strings.Join(columnList, ", "),
+				symbols.StatementPlaceholderList,
+			)
+
+			gosrc.Println(
+				"%s, %s := %s.Prepare(%s.String())",
+				symbols.Statement,
+				symbols.StatementError,
+				scope.Get("receiver"),
+				symbols.QueryBuffer,
+			)
+
+			gosrc.WithIf("%s != nil", func(url.Values) error {
+				gosrc.Println("return -1, %s", symbols.StatementError)
+				return nil
+			}, symbols.StatementError)
+
+			gosrc.Println("defer %s.Close()\n", symbols.Statement)
+
+			gosrc.Println(
+				"%s, %s := %s.Exec(%s...)",
+				symbols.ExecResult,
+				symbols.ExecError,
+				symbols.Statement,
+				symbols.StatementValueList,
+			)
+
+			gosrc.WithIf("%s != nil", func(url.Values) error {
+				gosrc.Println("return -1, %s", symbols.ExecError)
+				return nil
+			}, symbols.ExecError)
+
+			gosrc.Println("%s, %s := %s.RowsAffected()", symbols.AffectedResult, symbols.AffectedError, symbols.ExecResult)
+
+			gosrc.WithIf("%s != nil", func(url.Values) error {
+				gosrc.Println("return -1, %s", symbols.AffectedError)
+				return nil
+			}, symbols.AffectedError)
+
+			gosrc.Println("return %s, nil", symbols.AffectedResult)
+			return nil
+		})
+
+		gosrc.Println("/* %s %s %s %s", storeName, recordName, methodName, tableName)
+		gosrc.Println("*/")
+
+		if e == nil {
+			imports <- "fmt"
+			imports <- "bytes"
+			imports <- "strings"
+		}
+
+		pw.CloseWithError(e)
+	}()
+
+	return pr
+}

--- a/marlow/features/createable_test.go
+++ b/marlow/features/createable_test.go
@@ -1,0 +1,91 @@
+package features
+
+import "io"
+import "sync"
+import "bytes"
+import "testing"
+import "net/url"
+import "github.com/franela/goblin"
+import "github.com/dadleyy/marlow/marlow/constants"
+
+type createableTestScaffold struct {
+	buffer *bytes.Buffer
+
+	imports chan string
+	record  url.Values
+	fields  map[string]url.Values
+
+	received map[string]bool
+	closed   bool
+	wg       *sync.WaitGroup
+}
+
+func (s *createableTestScaffold) g() io.Reader {
+	return NewCreateableGenerator(s.record, s.fields, s.imports)
+}
+
+func Test_Createable(t *testing.T) {
+	g := goblin.Goblin(t)
+
+	var scaffold *createableTestScaffold
+
+	g.Describe("createable test suite", func() {
+
+		g.BeforeEach(func() {
+			scaffold = &createableTestScaffold{
+				buffer:   new(bytes.Buffer),
+				wg:       &sync.WaitGroup{},
+				imports:  make(chan string),
+				record:   make(url.Values),
+				fields:   make(map[string]url.Values),
+				received: make(map[string]bool),
+				closed:   false,
+			}
+
+			scaffold.wg.Add(1)
+
+			go func() {
+				for i := range scaffold.imports {
+					scaffold.received[i] = true
+				}
+				scaffold.wg.Done()
+			}()
+		})
+
+		g.AfterEach(func() {
+			if scaffold.closed != false {
+				return
+			}
+
+			close(scaffold.imports)
+			scaffold.wg.Wait()
+		})
+
+		g.Describe("with a valid record config", func() {
+
+			g.BeforeEach(func() {
+				scaffold.record.Set(constants.RecordNameConfigOption, "Author")
+				scaffold.record.Set(constants.TableNameConfigOption, "authors")
+				scaffold.record.Set(constants.UpdateFieldMethodPrefixConfigOption, "Update")
+				scaffold.record.Set(constants.StoreNameConfigOption, "AuthorStore")
+
+				scaffold.fields["ID"] = url.Values{
+					"type": []string{"int"},
+				}
+
+				scaffold.fields["Name"] = url.Values{
+					"type": []string{"string"},
+				}
+
+				scaffold.fields["UniversityID"] = url.Values{
+					"type": []string{"sql.NullInt64"},
+				}
+			})
+
+			g.It("generates valid golang", func() {
+				_, e := io.Copy(scaffold.buffer, scaffold.g())
+				g.Assert(e).Equal(nil)
+			})
+		})
+	})
+}

--- a/marlow/record_reader.go
+++ b/marlow/record_reader.go
@@ -153,6 +153,7 @@ func readRecord(writer io.Writer, config url.Values, fields map[string]url.Value
 	enabled := make(map[string]bool)
 
 	readers := []io.Reader{
+		features.NewCreateableGenerator(config, fields, imports),
 		features.NewDeleteableGenerator(config, fields, imports),
 	}
 


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`951ff09`] | [`GH-53`] creation api. All CRUD operations have basic coverage!! 🍾 🎉 |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |

[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`951ff09`]: https://github.com/dadleyy/marlow/commit/951ff095e6d505a4f636b7f93ef4352ce15020e0
[`GH-53`]: https://github.com/dadleyy/marlow/issues/53