### PR TITLE
chore(cleanup) removing un-used methods on generated store struct

### DIFF
--- a/examples/library/models/book.go
+++ b/examples/library/models/book.go
@@ -1,5 +1,6 @@
 package models
 
+import "fmt"
 import "database/sql"
 
 //go:generate marlowc -input book.go
@@ -17,6 +18,6 @@ type Book struct {
 }
 
 // GetPageContents is a dummy no-op function
-func (b *Book) GetPageContents(page int) (string, error) {
-	return "", nil
+func (b *Book) String() string {
+	return fmt.Sprintf("%s (%d pages)", b.Title, b.PageCount)
 }

--- a/examples/library/models/book_test.go
+++ b/examples/library/models/book_test.go
@@ -220,6 +220,15 @@ func Test_Book(t *testing.T) {
 			g.Assert(results[1]).Equal(2)
 		})
 
+		g.It("returns source struct instances that support source method calls", func() {
+			results, e := store.FindBooks(&BookBlueprint{
+				ID: []int{1},
+			})
+			g.Assert(e).Equal(nil)
+			title := fmt.Sprintf("%s", results[0])
+			g.Assert(title).Equal("book-1 (10 pages)")
+		})
+
 		g.It("allows the consumer to select explicit book titles", func() {
 			results, e := store.SelectTitles(&BookBlueprint{
 				ID: []int{1, 2},

--- a/marlow/features/store.go
+++ b/marlow/features/store.go
@@ -1,7 +1,6 @@
 package features
 
 import "io"
-import "fmt"
 import "net/url"
 import "github.com/dadleyy/marlow/marlow/writing"
 import "github.com/dadleyy/marlow/marlow/constants"
@@ -19,62 +18,6 @@ func writeStore(destination io.Writer, record url.Values, imports chan<- string)
 		return e
 	}
 
-	symbols := map[string]string{
-		"STATEMENT_PARAM": "_statement",
-		"ARGUMENTS_PARAM": "_args",
-	}
-
-	qParams := []writing.FuncParam{
-		{Symbol: symbols["STATEMENT_PARAM"], Type: "string"},
-		{Symbol: symbols["ARGUMENTS_PARAM"], Type: "...interface{}"},
-	}
-
-	qReturns := []string{"*sql.Rows", "error"}
-	eReturns := []string{"sql.Result", "error"}
-
-	e = out.WithMethod("q", storeName, qParams, qReturns, func(scope url.Values) error {
-		receiver := scope.Get("receiver")
-		condition := fmt.Sprintf("%s.DB == nil || %s.Ping() != nil", receiver, receiver)
-
-		e := out.WithIf(condition, func(url.Values) error {
-			out.Println("return nil, fmt.Errorf(\"not-connected\")")
-			return nil
-		})
-
-		if e != nil {
-			return e
-		}
-
-		out.Println("return %s.Query(%s, %s...)", receiver, symbols["STATEMENT_PARAM"], symbols["ARGUMENTS_PARAM"])
-		return nil
-	})
-
-	if e != nil {
-		return e
-	}
-
-	e = out.WithMethod("e", storeName, qParams, eReturns, func(scope url.Values) error {
-		receiver := scope.Get("receiver")
-		condition := fmt.Sprintf("%s.DB == nil || %s.Ping() != nil", receiver, receiver)
-
-		e := out.WithIf(condition, func(url.Values) error {
-			out.Println("return nil, fmt.Errorf(\"not-connected\")")
-			return nil
-		})
-
-		if e != nil {
-			return e
-		}
-
-		out.Println("return %s.Exec(%s, %s...)", receiver, symbols["STATEMENT_PARAM"], symbols["ARGUMENTS_PARAM"])
-		return nil
-	})
-
-	if e != nil {
-		return e
-	}
-
-	imports <- "fmt"
 	imports <- "database/sql"
 	return nil
 }

--- a/marlow/features/store_test.go
+++ b/marlow/features/store_test.go
@@ -88,7 +88,7 @@ func Test_StoreGenerator(t *testing.T) {
 			g.It("injects fmt and sql packages into import stream", func() {
 				io.Copy(scaffold.output, scaffold.g())
 				scaffold.close()
-				g.Assert(scaffold.received["fmt"]).Equal(true)
+				g.Assert(len(scaffold.received)).Equal(1)
 				g.Assert(scaffold.received["database/sql"]).Equal(true)
 			})
 


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`9cb78c0`] | cleaning up un-used un-exported methods from store interfaces |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |

[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`9cb78c0`]: https://github.com/dadleyy/marlow/commit/9cb78c0fa209450dfccc13d9f516a6216c5874d4