### PR TITLE
adding support for wider range of numeric field types

### DIFF
--- a/examples/library/data/schema.sql
+++ b/examples/library/data/schema.sql
@@ -3,7 +3,9 @@ drop table if exists authors;
 create table authors (
   id INTEGER PRIMARY KEY,
   name TEXT,
-  university_id INTEGER
+  university_id INTEGER,
+  rating REAL NOT NULL DEFAULT '100.00',
+  flags INTEGER NOT NULL DEFAULT 0
 );
 
 drop table if exists books;

--- a/examples/library/models/author.go
+++ b/examples/library/models/author.go
@@ -12,4 +12,6 @@ type Author struct {
 	ID           int           `marlow:"column=id&autoIncrement=true"`
 	Name         string        `marlow:"column=name"`
 	UniversityID sql.NullInt64 `marlow:"column=university_id"`
+	ReaderRating float64       `marlow:"column=rating"`
+	AuthorFlags  uint8         `marlow:"column=flags"`
 }


### PR DESCRIPTION
closes GH-63

### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`48d8de8`] | using the [`go/types`] package for field blueprint method generation |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |
| [:evergreen_tree:][contributing] | [`GH-63/numeric`][branch-url] |

[branch-url]: https://github.com/dadleyy/marlow/tree/GH-63/numeric
[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`48d8de8`]: https://github.com/dadleyy/marlow/commit/48d8de87474eae06f2710899a5f8a0e9dd32d1fc
[`go/types`]: https://golang.org/pkg/go/types/#BasicInfo