### PR TITLE
returning id from record creation api

### DIFF
--- a/examples/library/models/author_test.go
+++ b/examples/library/models/author_test.go
@@ -339,11 +339,10 @@ func Test_Author(t *testing.T) {
 			g.It("returns the number of authors created", func() {
 				s, e := store.CreateAuthors(Author{Name: "Danny"}, Author{Name: "Amelia"})
 				g.Assert(e).Equal(nil)
-				g.Assert(s).Equal(2)
-				found, e := store.FindAuthors(&AuthorBlueprint{Name: []string{"Amelia"}})
+				found, e := store.FindAuthors(&AuthorBlueprint{ID: []int{int(s)}})
 				g.Assert(e).Equal(nil)
 				g.Assert(len(found)).Equal(1)
-				g.Assert(found[0].ID > 0).Equal(true)
+				g.Assert(found[0].Name).Equal("Amelia")
 			})
 		})
 

--- a/examples/library/models/book_test.go
+++ b/examples/library/models/book_test.go
@@ -360,7 +360,11 @@ func Test_Book(t *testing.T) {
 					{Title: "Harry Potter", PageCount: 100, AuthorID: 2},
 				}...)
 				g.Assert(e).Equal(nil)
-				g.Assert(s).Equal(2)
+
+				p, e := store.FindBooks(&BookBlueprint{ID: []int{int(s)}})
+				g.Assert(e).Equal(nil)
+				g.Assert(p[0].Title).Equal("Harry Potter")
+
 				found, e := store.FindBooks(&BookBlueprint{Title: []string{"Harry Potter"}})
 				g.Assert(e).Equal(nil)
 				g.Assert(len(found)).Equal(1)

--- a/marlow/createable.go
+++ b/marlow/createable.go
@@ -148,7 +148,7 @@ func newCreateableGenerator(record marlowRecord) io.Reader {
 				return nil
 			}, symbols.ExecError)
 
-			gosrc.Println("%s, %s := %s.RowsAffected()", symbols.AffectedResult, symbols.AffectedError, symbols.ExecResult)
+			gosrc.Println("%s, %s := %s.LastInsertId()", symbols.AffectedResult, symbols.AffectedError, symbols.ExecResult)
 
 			gosrc.WithIf("%s != nil", func(url.Values) error {
 				gosrc.Println("return -1, %s", symbols.AffectedError)


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`07fbae1`] | returning the last inserted id from record creation api |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |
| [:evergreen_tree:][contributing] | [`return-id`][branch-url] |

[branch-url]: https://github.com/dadleyy/marlow/tree/return-id
[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`07fbae1`]: https://github.com/dadleyy/marlow/commit/07fbae1f73f6e4ea2743eb9cec75a5d177529d0b