### PR TITLE
correcting ordering when field column diff from name

### DIFF
--- a/examples/library/data/schema.sql
+++ b/examples/library/data/schema.sql
@@ -1,7 +1,7 @@
 drop table if exists authors;
 
 create table authors (
-  id INTEGER PRIMARY KEY,
+  system_id INTEGER PRIMARY KEY,
   name TEXT,
   university_id INTEGER,
   rating REAL NOT NULL DEFAULT '100.00',
@@ -11,7 +11,7 @@ create table authors (
 drop table if exists books;
 
 create table books (
-  id INTEGER PRIMARY KEY,
+  system_id INTEGER PRIMARY KEY,
   title TEXT,
   author INTEGER NOT NULL,
   series INTEGER,

--- a/examples/library/main.go
+++ b/examples/library/main.go
@@ -28,7 +28,7 @@ func withTx(db *sql.DB, block func(*sql.Tx) error) error {
 }
 
 func addBooks(tx *sql.Tx) error {
-	stmt, e := tx.Prepare("insert into books(id, title, author, page_count) values(?, ?, ?, ?)")
+	stmt, e := tx.Prepare("insert into books(system_id, title, author, page_count) values(?, ?, ?, ?)")
 
 	if e != nil {
 		log.Fatal(e)
@@ -48,7 +48,7 @@ func addBooks(tx *sql.Tx) error {
 }
 
 func addAuthors(tx *sql.Tx) error {
-	stmt, e := tx.Prepare("insert into authors(id, name) values(?, ?)")
+	stmt, e := tx.Prepare("insert into authors(system_id, name) values(?, ?)")
 
 	if e != nil {
 		log.Fatal(e)

--- a/examples/library/models/author.go
+++ b/examples/library/models/author.go
@@ -9,7 +9,7 @@ import "database/sql"
 // Author represents an author of a book.
 type Author struct {
 	table        bool          `marlow:"tableName=authors"`
-	ID           int           `marlow:"column=id&autoIncrement=true"`
+	ID           int           `marlow:"column=system_id&autoIncrement=true"`
 	Name         string        `marlow:"column=name"`
 	UniversityID sql.NullInt64 `marlow:"column=university_id"`
 	ReaderRating float64       `marlow:"column=rating"`

--- a/examples/library/models/author_test.go
+++ b/examples/library/models/author_test.go
@@ -12,7 +12,7 @@ import "github.com/dadleyy/marlow/marlow"
 func addAuthorRow(db *sql.DB, values ...[]string) error {
 	for _, rowValues := range values {
 		valueString := strings.Join(rowValues, ",")
-		statement := fmt.Sprintf("insert into authors (id,name) values(%s);", valueString)
+		statement := fmt.Sprintf("insert into authors (system_id,name) values(%s);", valueString)
 		r, e := db.Exec(statement)
 
 		if e != nil {
@@ -78,7 +78,7 @@ func Test_Author(t *testing.T) {
 				IDRange: []int{1, 2},
 			})
 
-			g.Assert(r).Equal("WHERE authors.id > ? AND authors.id < ?")
+			g.Assert(r).Equal("WHERE authors.system_id > ? AND authors.system_id < ?")
 		})
 
 		g.It("supports in on uint column querying", func() {
@@ -103,7 +103,7 @@ func Test_Author(t *testing.T) {
 
 		g.It("supports 'IN' on ID column querying", func() {
 			r := fmt.Sprintf("%s", &AuthorBlueprint{ID: []int{1, 2, 3}})
-			g.Assert(r).Equal("WHERE authors.id IN (?,?,?)")
+			g.Assert(r).Equal("WHERE authors.system_id IN (?,?,?)")
 		})
 
 		g.It("supports a combination of range and 'IN' on ID column querying", func() {
@@ -112,7 +112,7 @@ func Test_Author(t *testing.T) {
 				IDRange: []int{1, 4},
 			})
 
-			g.Assert(r).Equal("WHERE authors.id IN (?,?,?) AND authors.id > ? AND authors.id < ?")
+			g.Assert(r).Equal("WHERE authors.system_id IN (?,?,?) AND authors.system_id > ? AND authors.system_id < ?")
 		})
 
 	})
@@ -133,9 +133,9 @@ func Test_Author(t *testing.T) {
 
 			g.Assert(addAuthorRow(db, authors...)).Equal(nil)
 
-			_, e = db.Exec("insert into authors (id,name,university_id) values(1337,'learned author',10);")
+			_, e = db.Exec("insert into authors (system_id,name,university_id) values(1337,'learned author',10);")
 			g.Assert(e).Equal(nil)
-			_, e = db.Exec("insert into authors (id,name,university_id) values(1338,'other author',null);")
+			_, e = db.Exec("insert into authors (system_id,name,university_id) values(1338,'other author',null);")
 			g.Assert(e).Equal(nil)
 		})
 

--- a/examples/library/models/book.go
+++ b/examples/library/models/book.go
@@ -10,7 +10,7 @@ import "database/sql"
 // Book represents a book in the example application
 type Book struct {
 	table     string        `marlow:"defaultLimit=10"`
-	ID        int           `marlow:"column=id&autoIncrement=true"`
+	ID        int           `marlow:"column=system_id&autoIncrement=true"`
 	Title     string        `marlow:"column=title"`
 	AuthorID  int           `marlow:"column=author&references=Author"`
 	SeriesID  sql.NullInt64 `marlow:"column=series"`

--- a/marlow/field_list.go
+++ b/marlow/field_list.go
@@ -1,0 +1,22 @@
+package marlow
+
+import "strings"
+
+type field struct {
+	name   string
+	column string
+}
+
+type fieldList []field
+
+func (l fieldList) Less(i, j int) bool {
+	return strings.ToLower(l[i].name) < strings.ToLower(l[j].name)
+}
+
+func (l fieldList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+func (l fieldList) Len() int {
+	return len(l)
+}

--- a/marlow/field_list_test.go
+++ b/marlow/field_list_test.go
@@ -1,0 +1,24 @@
+package marlow
+
+import "sort"
+import "testing"
+
+import "github.com/franela/goblin"
+
+func Test_FieldList(t *testing.T) {
+	g := goblin.Goblin(t)
+
+	g.Describe("fieldList test suite", func() {
+
+		g.It("sorts correctly", func() {
+			l := fieldList{
+				{name: "z", column: "a"},
+				{name: "a", column: "z"},
+			}
+			sort.Sort(l)
+			g.Assert(l[0].name).Equal("a")
+			g.Assert(l[1].name).Equal("z")
+		})
+
+	})
+}

--- a/marlow/record.go
+++ b/marlow/record.go
@@ -1,5 +1,7 @@
 package marlow
 
+import "fmt"
+import "sort"
 import "strings"
 import "net/url"
 import "github.com/dadleyy/marlow/marlow/writing"
@@ -14,6 +16,19 @@ type marlowRecord struct {
 	importRegistry map[string]bool
 
 	storeChannel chan writing.FuncDecl
+}
+
+func (r *marlowRecord) fieldList() fieldList {
+	list := make(fieldList, 0, len(r.fields))
+
+	for name, c := range r.fields {
+		column := fmt.Sprintf("%s.%s", r.table(), c.Get(constants.ColumnConfigOption))
+		list = append(list, field{name: name, column: column})
+	}
+
+	sort.Sort(list)
+
+	return list
 }
 
 func (r *marlowRecord) registerStoreMethod(method writing.FuncDecl) {


### PR DESCRIPTION
closes GH-70

### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`a20fdbc`] | correcting ordering on fields w/ columname mismatch [GH-70] |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |
| [:evergreen_tree:][contributing] | [`ordering`][branch-url] |

[branch-url]: https://github.com/dadleyy/marlow/tree/ordering
[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`a20fdbc`]: https://github.com/dadleyy/marlow/commit/a20fdbc4168c87500b36c2d5b59b69e9c7b27acc