### PR TITLE
adding "inclusive" field to blueprints for "OR" clauses

### DIFF
--- a/examples/library/models/author_test.go
+++ b/examples/library/models/author_test.go
@@ -78,7 +78,7 @@ func Test_Author(t *testing.T) {
 				IDRange: []int{1, 2},
 			})
 
-			g.Assert(r).Equal("WHERE authors.system_id > ? AND authors.system_id < ?")
+			g.Assert(r).Equal("WHERE (authors.system_id > ? AND authors.system_id < ?)")
 		})
 
 		g.It("supports in on uint column querying", func() {
@@ -88,12 +88,12 @@ func Test_Author(t *testing.T) {
 
 		g.It("supports range on uint column querying", func() {
 			r := fmt.Sprintf("%s", &AuthorBlueprint{AuthorFlagsRange: []uint8{1, 2}})
-			g.Assert(r).Equal("WHERE authors.flags > ? AND authors.flags < ?")
+			g.Assert(r).Equal("WHERE (authors.flags > ? AND authors.flags < ?)")
 		})
 
 		g.It("supports range on float64 column querying", func() {
 			r := fmt.Sprintf("%s", &AuthorBlueprint{ReaderRatingRange: []float64{1, 2}})
-			g.Assert(r).Equal("WHERE authors.rating > ? AND authors.rating < ?")
+			g.Assert(r).Equal("WHERE (authors.rating > ? AND authors.rating < ?)")
 		})
 
 		g.It("supports 'IN' on float64 column querying", func() {
@@ -112,9 +112,18 @@ func Test_Author(t *testing.T) {
 				IDRange: []int{1, 4},
 			})
 
-			g.Assert(r).Equal("WHERE authors.system_id IN (?,?,?) AND authors.system_id > ? AND authors.system_id < ?")
+			g.Assert(r).Equal("WHERE authors.system_id IN (?,?,?) AND (authors.system_id > ? AND authors.system_id < ?)")
 		})
 
+		g.It("supports making a blueprint inclusive", func() {
+			r := fmt.Sprintf("%s", &AuthorBlueprint{
+				NameLike:  []string{"%rodger%"},
+				IDRange:   []int{1, 4},
+				Inclusive: true,
+			})
+
+			g.Assert(r).Equal("WHERE (authors.system_id > ? AND authors.system_id < ?) OR authors.name LIKE ?")
+		})
 	})
 
 	g.Describe("Author model & generated store test suite", func() {

--- a/examples/library/models/book_test.go
+++ b/examples/library/models/book_test.go
@@ -46,6 +46,16 @@ func Test_Book(t *testing.T) {
 			str := fmt.Sprintf("%s", &BookBlueprint{TitleLike: []string{"b"}})
 			g.Assert(str).Equal("WHERE books.title LIKE ?")
 		})
+
+		g.It("allows inclusive (OR) blueprints", func() {
+			str := fmt.Sprintf("%s", &BookBlueprint{
+				TitleLike: []string{"b", "c"},
+				IDRange:   []int{1, 2},
+				Inclusive: true,
+			})
+			expected := "WHERE (books.system_id > ? AND books.system_id < ?) OR books.title LIKE ? OR books.title LIKE ?"
+			g.Assert(str).Equal(expected)
+		})
 	})
 
 	g.Describe("Book model & generated store", func() {


### PR DESCRIPTION
closes GH-73

### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`0daa175`] | adding `Inclusive` field to blueprint for `OR`-ing clause items closes [`GH-73`] |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |
| [:evergreen_tree:][contributing] | [`GH-73/inclusive`][branch-url] |

[branch-url]: https://github.com/dadleyy/marlow/tree/GH-73/inclusive
[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`0daa175`]: https://github.com/dadleyy/marlow/commit/0daa17529259297083222068fe03fe2d51d5825a
[`GH-73`]: https://github.com/dadleyy/marlow/issues/73