### PR TITLE
adding go 1.10 to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: go
 services:
   - postgresql
 go:
-  - 1.8
-  - 1.9
+  - "1.8"
+  - "1.9"
+  - "1.10"
 before_script:
   - psql -c 'create database marlow_test;' -U postgres
 install:


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`bf58981`] | go 1.10 released! |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |

[branch-url]: https://github.com/dadleyy/marlow
[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`bf58981`]: https://github.com/dadleyy/marlow/commit/bf5898138a49fb3d1016f8e5475df5737ad8e239