### PR TITLE
chore(reportcard) correcting misspellings + reducing complexity

### DIFF
--- a/examples/library/models/database_connections.go
+++ b/examples/library/models/database_connections.go
@@ -18,7 +18,7 @@ type DatabaseConnections struct {
 	sqlite   *sql.DB
 }
 
-// Initialize opens the various datbase connection types and seeds their database tables.
+// Initialize opens the various database connection types and seeds their database tables.
 func (db *DatabaseConnections) Initialize() error {
 	sqlite, e := sql.Open("sqlite3", db.Config.SQLite.Filename)
 

--- a/examples/library/models/multi_auto.go
+++ b/examples/library/models/multi_auto.go
@@ -1,6 +1,6 @@
 package models
 
-// MultiAuto represents a record w/ mutliple auto-increment directives on a postgres model.
+// MultiAuto represents a record w/ multiple auto-increment directives on a postgres model.
 type MultiAuto struct {
 	table  bool   `marlow:"tableName=multi_auto&dialect=postgres&primaryKey=id"`
 	ID     uint   `marlow:"column=id&autoIncrement=true"`

--- a/examples/library/models/multi_auto_test.go
+++ b/examples/library/models/multi_auto_test.go
@@ -14,7 +14,7 @@ func Test_MultiAuto(t *testing.T) {
 	var db *sql.DB
 	var store MultiAutoStore
 
-	g.Describe("Model with mutliple auto increment columns", func() {
+	g.Describe("Model with multiple auto increment columns", func() {
 		g.Before(func() {
 			var e error
 			config := struct {
@@ -73,7 +73,7 @@ func Test_MultiAuto(t *testing.T) {
 			})
 		})
 
-		g.It("allows consumer to delete mutli auto records", func() {
+		g.It("allows consumer to delete multi auto records", func() {
 			id, e := store.CreateMultiAutos(MultiAuto{Name: "to-delete"})
 			g.Assert(e).Equal(nil)
 			_, e = store.DeleteMultiAutos(&MultiAutoBlueprint{ID: []uint{uint(id)}})
@@ -125,7 +125,7 @@ func Test_MultiAuto(t *testing.T) {
 				g.Assert(e).Equal(nil)
 			})
 
-			g.It("allows the consumer to count mutli autos", func() {
+			g.It("allows the consumer to count multi autos", func() {
 				a, e := store.CountMultiAutos(&MultiAutoBlueprint{Limit: 1})
 				g.Assert(e).Equal(nil)
 				g.Assert(a > 0).Equal(true)

--- a/marlowc/main.go
+++ b/marlowc/main.go
@@ -16,10 +16,10 @@ import "github.com/dadleyy/marlow/marlow"
 import "github.com/dadleyy/marlow/marlow/constants"
 
 func main() {
-	cwd, err := os.Getwd()
+	cwd, e := os.Getwd()
 
-	if err != nil {
-		exit("unable to get current directory", err)
+	if e != nil {
+		exit("unable to get current directory", e)
 	}
 
 	options := cliOptions{ext: constants.DefaultMarlowFileExtension}
@@ -31,15 +31,10 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
-	// Check to ensure the input exists on the filesystem.
-	if _, e := os.Stat(options.input); e != nil {
-		exit("must provide a valid input for compilation", nil)
-	}
+	sourceFiles, e := loadFileNames(options.input)
 
-	sourceFiles, err := loadFileNames(options.input)
-
-	if err != nil {
-		exit("unable to load package from input", err)
+	if e != nil {
+		exit("unable to load package from input", e)
 	}
 
 	var progressOut io.Writer = new(bytes.Buffer)
@@ -120,13 +115,8 @@ func main() {
 	progress.Stop()
 	<-done
 
-	// If no files were the target of compilation,
-	if len(results) == 0 {
-		return
-	}
-
-	// If silent, finish here.
-	if options.silent == true {
+	// If no files were the target of compilation, or the silent flag was used, do nothing.
+	if len(results) == 0 || options.silent == true {
 		return
 	}
 


### PR DESCRIPTION
### Notable changes

| commit/diff | reason |
| :--- | :--- |
| [`f6cdd38`] | correcting misspellings + reducing complexity in compiler `main`. |

| [:tophat:][contributing] | @dadleyy |
| :--- | :--- |
| [:paperclip:][contributing] | |
| [:evergreen_tree:][contributing] | [`misspell`][branch-url] |

[branch-url]: https://github.com/dadleyy/marlow/tree/misspell
[contributing]: https://github.com/dadleyy/marlow/blob/master/.github/CONTRIBUTING.md
[`f6cdd38`]: https://github.com/dadleyy/marlow/commit/f6cdd38c6929488d6b4dcf2490546ac98152f2f9